### PR TITLE
修复Climate频繁不可用、Select控制失效、日志报错等问题

### DIFF
--- a/custom_components/tcl/helpers.py
+++ b/custom_components/tcl/helpers.py
@@ -9,3 +9,9 @@ def try_read_as_bool(value):
         return value == 1
 
     raise ValueError('[{}]无法被转为bool'.format(value))
+
+def get_key_by_value(d, value):
+    for key, val in d.items():
+        if val == value:
+            return key
+    return None  # 如果没有找到，返回None

--- a/custom_components/tcl/select.py
+++ b/custom_components/tcl/select.py
@@ -9,6 +9,7 @@ from . import async_register_entity
 from .core.attribute import TclAttribute
 from .core.device import TclDevice
 from .entity import TclAbstractEntity
+from .helpers import get_key_by_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,9 +37,13 @@ class TclSelect(TclAbstractEntity, SelectEntity):
             self._attr_current_option = self._get_value_from_comparison_table(self._attributes_data[self._attribute.key])
 
     def select_option(self, option: str) -> None:
-        self._send_command({
-            self._attribute.key: option
-        })
+        _LOGGER.debug('shady '+self._attribute.key+' '+option)
+        #这里需要通过option反查key
+        key = get_key_by_value(self._attribute.ext.get('value_comparison_table'),option)
+        if key:
+            self._send_command({
+                self._attribute.key: key
+            })
 
     def _get_value_from_comparison_table(self, value):
         value_comparison_table = self._attribute.ext.get('value_comparison_table', {})


### PR DESCRIPTION
1.修复Climate频繁被设置为不可用
2.删除Climate中的异步控制，异步控制不能用在返回为None的函数
3.修复Select属性控制失效